### PR TITLE
Allow calling the export/constructor without the new keyword.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ var Uint8Array = global.Uint8Array;
  */
 function ReadableBlobStream(blob, opts)
 {
+        if (!(this instanceof ReadableBlobStream)) {
+          return new ReadableBlobStream(blob, opts);
+        }
+
         opts = opts || {};
         opts.objectMode = false;
         Readable.call(this, opts);


### PR DESCRIPTION
This change fixes buggy and unexpected behavior when the export/ReadableBlobStream constructor is called without the `new` keyword.
